### PR TITLE
Prioritizes Render's PORT environment variable

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -41,9 +41,12 @@ func main() {
 	handler.SetupRoutes(app)
 
 	// Get service-specific port or use default
-	port := os.Getenv("GATEWAY_PORT")
+	port := os.Getenv("PORT") // Render's standard PORT variable
 	if port == "" {
-		port = "8081" // Default port for API Gateway
+		port = os.Getenv("GATEWAY_PORT")
+		if port == "" {
+			port = "8081" // Default port for API Gateway
+		}
 	}
 
 	utils.Info("API Gateway running on port " + port)

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -65,11 +65,14 @@ func main() {
 	handler.SetupRoutes(app)
 
 	// Get service-specific port or use default
-	port := os.Getenv("AUTH_SERVICE_PORT")
+	port := os.Getenv("PORT") // Render's standard PORT variable
 	if port == "" {
-		port = os.Getenv("DEFAULT_PORT")
+		port = os.Getenv("AUTH_SERVICE_PORT")
 		if port == "" {
-			port = "3004" // Default port for auth service
+			port = os.Getenv("DEFAULT_PORT")
+			if port == "" {
+				port = "3004" // Default port for auth service
+			}
 		}
 	}
 

--- a/services/employee-service/cmd/main.go
+++ b/services/employee-service/cmd/main.go
@@ -72,11 +72,14 @@ func main() {
 
 
     // Get service-specific port or use default
-    port := os.Getenv("EMPLOYEE_SERVICE_PORT")
+    port := os.Getenv("PORT") // Render's standard PORT variable
     if port == "" {
-        port = os.Getenv("DEFAULT_PORT")
+        port = os.Getenv("EMPLOYEE_SERVICE_PORT")
         if port == "" {
-            port = "3002" // Fallback for employee service
+            port = os.Getenv("DEFAULT_PORT")
+            if port == "" {
+                port = "3002" // Fallback for employee service
+            }
         }
     }
 


### PR DESCRIPTION
Prioritizes the `PORT` environment variable (Render's standard) when determining the service port. This ensures compatibility with Render's deployment environment by checking `PORT` first, then falling back to service-specific environment variables and finally to the default port.