### PR TITLE
fixed vercel spa issue

### DIFF
--- a/apps/business-app/src/App.tsx
+++ b/apps/business-app/src/App.tsx
@@ -33,7 +33,7 @@ const App: React.FC = () => {
         {/* Protected routes */}
         <Route element={<RequireAuth />}>
           <Route path="/" element={<AdminLayout />}>
-            <Route index element={<Navigate to="overview" />} />
+            <Route index element={<Navigate to="staff" />} />
             <Route path="staff" element={<StaffManagement />} />
             <Route
               path="staff/:staffId/availability"

--- a/apps/business-app/src/api/axios.ts
+++ b/apps/business-app/src/api/axios.ts
@@ -1,7 +1,8 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
 
 // dynamic env value; fallback to gateway at 8081
-const BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8081";
+const BASE_URL =
+  import.meta.env.VITE_API_URL || "https://staff-api-gateway.onrender.com";
 
 // We'll get the store reference dynamically to avoid circular dependency
 let store: any = null;

--- a/apps/business-app/vercel.json
+++ b/apps/business-app/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces changes to improve routing, update API configurations, and add deployment configuration for the business app. The most important changes include modifying the default route for protected pages, updating the base URL for API requests, and adding a `vercel.json` file for deployment rewrites.

### Routing updates:
* [`apps/business-app/src/App.tsx`](diffhunk://#diff-50bf1cf0d389ab8d8a606db983fed09a90f422b78983776d544afaa53a9c1cf6L36-R36): Changed the default route for protected pages from `overview` to `staff`. This ensures users are directed to the staff management section upon accessing the app.

### API configuration updates:
* [`apps/business-app/src/api/axios.ts`](diffhunk://#diff-adef6db0f0083d519a27f863ea7dd33e113efc5d7e4110eb639e62dc4a85c0a3L4-R5): Updated the `BASE_URL` to use `https://staff-api-gateway.onrender.com` as the fallback instead of `http://localhost:8081`. This aligns the API configuration with the production environment.

### Deployment configuration:
* [`apps/business-app/vercel.json`](diffhunk://#diff-c4835565e749ca6e0ccff13f071e0fe4d31ab455a0b8809b0436baec1b90ffb5R1-R8): Added a `vercel.json` file to configure rewrites for deployment. This ensures all routes are redirected to `index.html` for proper handling in single-page applications.