### PR TITLE
added date srrip

### DIFF
--- a/apps/business-app/src/components/staff/tabs/availability/DailyAvailabilityTimeline.tsx
+++ b/apps/business-app/src/components/staff/tabs/availability/DailyAvailabilityTimeline.tsx
@@ -1,0 +1,386 @@
+import React from "react";
+import { EmployeeAvailabilityResponse } from "../../../../types/availability";
+
+interface TimelineSegment {
+  startMinutes: number;
+  endMinutes: number;
+  type: "WORKING" | "BREAK" | "TIME_OFF";
+  reason?: string;
+  widthPercentage: number;
+  startTime: Date;
+  endTime: Date;
+}
+
+interface DailyAvailabilityTimelineProps {
+  availabilityData: EmployeeAvailabilityResponse;
+  staffName: string;
+}
+
+const AVAILABILITY_COLORS = {
+  WORKING: {
+    bg: "bg-green-500/20",
+    border: "border-green-400/30",
+    text: "text-green-400",
+    label: "Available",
+  },
+  BREAK: {
+    bg: "bg-orange-500/20",
+    border: "border-orange-400/30",
+    text: "text-orange-400",
+    label: "Break",
+  },
+  TIME_OFF: {
+    bg: "bg-red-500/20",
+    border: "border-red-400/30",
+    text: "text-red-400",
+    label: "Unavailable",
+  },
+};
+
+const DailyAvailabilityTimeline: React.FC<DailyAvailabilityTimelineProps> = ({
+  availabilityData,
+  staffName,
+}) => {
+  // Helper function to convert UTC onetimeblock time to Sri Lankan time (add 5:30)
+  const convertOnetimeBlockTime = (utcTimeString: string): string => {
+    const utcDate = new Date(utcTimeString);
+    // Add 5 hours and 30 minutes for Sri Lankan time
+    const sriLankanDate = new Date(utcDate.getTime() + 5.5 * 60 * 60 * 1000);
+    return sriLankanDate.toISOString();
+  };
+
+  // Helper function to extract time from date string (for schedules and breaks - use as-is)
+  const extractTime = (timeString: string): string => {
+    // Extract just the time part from ISO string like "2025-07-02T09:00:00Z"
+    if (timeString.includes("T")) {
+      const timePart = timeString.split("T")[1];
+      const time = timePart.split(".")[0]; // Remove milliseconds if present
+      return time.replace("Z", ""); // Remove Z if present
+    }
+    return timeString;
+  };
+
+  // Helper function to convert time string to minutes since start of schedule
+  const getMinutesFromStart = (
+    timeString: string,
+    scheduleStart: Date
+  ): number => {
+    const time = new Date(timeString);
+    return Math.floor((time.getTime() - scheduleStart.getTime()) / (1000 * 60));
+  };
+
+  // Helper function to format time (extract HH:MM from ISO string)
+  const formatTime = (timeString: string): string => {
+    const time = extractTime(timeString);
+    const [hours, minutes] = time.split(":");
+    const hour24 = parseInt(hours);
+    const hour12 = hour24 === 0 ? 12 : hour24 > 12 ? hour24 - 12 : hour24;
+    const ampm = hour24 >= 12 ? "PM" : "AM";
+    return `${hour12}:${minutes} ${ampm}`;
+  };
+
+  // Helper function to calculate duration
+  const calculateDuration = (startTime: string, endTime: string): string => {
+    const start = new Date(startTime);
+    const end = new Date(endTime);
+    const minutes = Math.floor((end.getTime() - start.getTime()) / (1000 * 60));
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+
+    if (hours > 0) {
+      return remainingMinutes > 0
+        ? `${hours}h ${remainingMinutes}m`
+        : `${hours}h`;
+    }
+    return `${remainingMinutes}m`;
+  };
+
+  if (!availabilityData.schedule) {
+    return (
+      <div className="bg-white/5 border border-white/10 rounded-lg p-4 backdrop-blur-sm">
+        <h4 className="font-medium text-white/95 mb-2">Daily Timeline</h4>
+        <div className="text-center py-8">
+          <span className="text-white/60">
+            No schedule available for this date
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const schedule = availabilityData.schedule;
+  const scheduleStart = new Date(schedule.start_time);
+  const scheduleEnd = new Date(schedule.end_time);
+  const totalMinutes = Math.floor(
+    (scheduleEnd.getTime() - scheduleStart.getTime()) / (1000 * 60)
+  );
+
+  // Create timeline events
+  const events: Array<{
+    time: number;
+    type: "START" | "END";
+    category: "BREAK" | "TIME_OFF";
+    reason?: string;
+  }> = [];
+
+  // Add break events
+  availabilityData.breaks.forEach((breakItem) => {
+    const startMinutes = getMinutesFromStart(
+      breakItem.start_time,
+      scheduleStart
+    );
+    const endMinutes = getMinutesFromStart(breakItem.end_time, scheduleStart);
+
+    if (startMinutes >= 0 && endMinutes <= totalMinutes) {
+      events.push({
+        time: startMinutes,
+        type: "START",
+        category: "BREAK",
+        reason: breakItem.reason,
+      });
+      events.push({
+        time: endMinutes,
+        type: "END",
+        category: "BREAK",
+        reason: breakItem.reason,
+      });
+    }
+  });
+
+  // Add time-off events (convert UTC to Sri Lankan time first)
+  availabilityData.onetimeblocks.forEach((block) => {
+    // Convert UTC times to Sri Lankan time for onetimeblocks only
+    const convertedStartTime = convertOnetimeBlockTime(block.start_time);
+    const convertedEndTime = convertOnetimeBlockTime(block.end_time);
+
+    const startMinutes = getMinutesFromStart(convertedStartTime, scheduleStart);
+    const endMinutes = getMinutesFromStart(convertedEndTime, scheduleStart);
+
+    if (startMinutes >= 0 && endMinutes <= totalMinutes) {
+      events.push({
+        time: startMinutes,
+        type: "START",
+        category: "TIME_OFF",
+        reason: block.reason,
+      });
+      events.push({
+        time: endMinutes,
+        type: "END",
+        category: "TIME_OFF",
+        reason: block.reason,
+      });
+    }
+  });
+
+  // Sort events by time
+  events.sort((a, b) => a.time - b.time);
+
+  // Create timeline segments
+  const segments: TimelineSegment[] = [];
+  let currentTime = 0;
+  let activeBreak = false;
+  let activeTimeOff = false;
+  let currentReason = "";
+
+  // Add timestamp points for rendering
+  const timeStamps = new Set<number>([0, totalMinutes]);
+
+  events.forEach((event) => {
+    if (currentTime < event.time) {
+      // Add segment from currentTime to event.time
+      const type = activeTimeOff
+        ? "TIME_OFF"
+        : activeBreak
+        ? "BREAK"
+        : "WORKING";
+      const widthPercentage = ((event.time - currentTime) / totalMinutes) * 100;
+
+      const segmentStartTime = new Date(
+        scheduleStart.getTime() + currentTime * 60 * 1000
+      );
+      const segmentEndTime = new Date(
+        scheduleStart.getTime() + event.time * 60 * 1000
+      );
+
+      segments.push({
+        startMinutes: currentTime,
+        endMinutes: event.time,
+        type,
+        reason: type !== "WORKING" ? currentReason : undefined,
+        widthPercentage,
+        startTime: segmentStartTime,
+        endTime: segmentEndTime,
+      });
+    }
+
+    timeStamps.add(event.time);
+
+    // Update state
+    if (event.category === "BREAK") {
+      if (event.type === "START") {
+        activeBreak = true;
+        currentReason = event.reason || "Break";
+      } else {
+        activeBreak = false;
+      }
+    } else if (event.category === "TIME_OFF") {
+      if (event.type === "START") {
+        activeTimeOff = true;
+        currentReason = event.reason || "Time Off";
+      } else {
+        activeTimeOff = false;
+      }
+    }
+
+    currentTime = event.time;
+  });
+
+  // Add final segment if needed
+  if (currentTime < totalMinutes) {
+    const type = activeTimeOff ? "TIME_OFF" : activeBreak ? "BREAK" : "WORKING";
+    const widthPercentage = ((totalMinutes - currentTime) / totalMinutes) * 100;
+
+    const segmentStartTime = new Date(
+      scheduleStart.getTime() + currentTime * 60 * 1000
+    );
+    const segmentEndTime = scheduleEnd;
+
+    segments.push({
+      startMinutes: currentTime,
+      endMinutes: totalMinutes,
+      type,
+      reason: type !== "WORKING" ? currentReason : undefined,
+      widthPercentage,
+      startTime: segmentStartTime,
+      endTime: segmentEndTime,
+    });
+  }
+
+  // Calculate totals for summary
+  const workingMinutes = segments
+    .filter((s) => s.type === "WORKING")
+    .reduce((sum, s) => sum + (s.endMinutes - s.startMinutes), 0);
+  const breakMinutes = segments
+    .filter((s) => s.type === "BREAK")
+    .reduce((sum, s) => sum + (s.endMinutes - s.startMinutes), 0);
+  const timeOffMinutes = segments
+    .filter((s) => s.type === "TIME_OFF")
+    .reduce((sum, s) => sum + (s.endMinutes - s.startMinutes), 0);
+
+  const formatMinutes = (minutes: number): string => {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+  };
+
+  // Convert timestamps to array and sort
+  const timeStampArray = Array.from(timeStamps).sort((a, b) => a - b);
+
+  return (
+    <div className="bg-white/5 border border-white/10 rounded-lg p-4 backdrop-blur-sm">
+      {/* Header */}
+      <div className="mb-4">
+        <h4 className="font-medium text-white/95 mb-2">Daily Timeline</h4>
+        <div className="flex flex-wrap items-center gap-4 text-sm">
+          <span className="text-white/70">
+            {staffName} -{" "}
+            {new Date(availabilityData.date).toLocaleDateString("en-US", {
+              weekday: "long",
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </span>
+          <div className="flex gap-4">
+            <span className="text-green-400">
+              Available: {formatMinutes(workingMinutes)}
+            </span>
+            {breakMinutes > 0 && (
+              <span className="text-orange-400">
+                Breaks: {formatMinutes(breakMinutes)}
+              </span>
+            )}
+            {timeOffMinutes > 0 && (
+              <span className="text-red-400">
+                Time Off: {formatMinutes(timeOffMinutes)}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Timeline Strip */}
+      <div className="mb-3">
+        <div className="flex w-full h-12 rounded-lg overflow-hidden border border-white/10">
+          {segments.map((segment, index) => (
+            <div
+              key={index}
+              className={`${AVAILABILITY_COLORS[segment.type].bg} ${
+                AVAILABILITY_COLORS[segment.type].border
+              } 
+                          border-r last:border-r-0 flex items-center justify-center relative group cursor-pointer
+                          hover:opacity-80 transition-opacity duration-200`}
+              style={{ width: `${segment.widthPercentage}%` }}
+            >
+              {/* Tooltip */}
+              <div
+                className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 
+                              bg-black/90 text-white text-xs rounded px-2 py-1 pointer-events-none z-10 whitespace-nowrap"
+              >
+                <div className="font-medium">
+                  {segment.reason || AVAILABILITY_COLORS[segment.type].label}
+                </div>
+                <div>
+                  {formatTime(segment.startTime.toISOString())} -{" "}
+                  {formatTime(segment.endTime.toISOString())}
+                </div>
+                <div>
+                  Duration:{" "}
+                  {calculateDuration(
+                    segment.startTime.toISOString(),
+                    segment.endTime.toISOString()
+                  )}
+                </div>
+              </div>
+
+              {/* Label inside segment (only if wide enough) */}
+              {segment.widthPercentage > 15 && (
+                <span
+                  className={`text-xs ${
+                    AVAILABILITY_COLORS[segment.type].text
+                  } font-medium`}
+                >
+                  {segment.reason || AVAILABILITY_COLORS[segment.type].label}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Time Labels */}
+      <div className="relative">
+        <div className="flex justify-between text-xs text-white/60">
+          {timeStampArray.map((minutes, index) => {
+            const timeAtMinutes = new Date(
+              scheduleStart.getTime() + minutes * 60 * 1000
+            );
+            const position = (minutes / totalMinutes) * 100;
+
+            return (
+              <div
+                key={index}
+                className="absolute transform -translate-x-1/2"
+                style={{ left: `${position}%` }}
+              >
+                {formatTime(timeAtMinutes.toISOString())}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DailyAvailabilityTimeline;

--- a/apps/business-app/src/store/slices/availabilitySlice.ts
+++ b/apps/business-app/src/store/slices/availabilitySlice.ts
@@ -5,6 +5,7 @@ import {
   RecurringBreak,
   OnetimeBlock,
   WeeklySchedule,
+  EmployeeAvailabilityResponse,
 } from "../../types/availability";
 
 // Define the shape of the availability state
@@ -13,6 +14,9 @@ interface AvailabilityState {
   schedules: Schedule[];
   recurringBreaks: RecurringBreak[];
   onetimeBlocks: OnetimeBlock[];
+
+  // Employee Availability Data (for specific dates)
+  employeeAvailability: EmployeeAvailabilityResponse | null;
 
   // UI State
   selectedEmployeeId: string | null;
@@ -23,6 +27,7 @@ interface AvailabilityState {
     schedules: boolean;
     recurringBreaks: boolean;
     onetimeBlocks: boolean;
+    employeeAvailability: boolean;
   };
 
   // Error states
@@ -30,6 +35,7 @@ interface AvailabilityState {
     schedules: string | null;
     recurringBreaks: string | null;
     onetimeBlocks: string | null;
+    employeeAvailability: string | null;
   };
 
   // Modal states
@@ -59,6 +65,9 @@ const initialState: AvailabilityState = {
   recurringBreaks: [],
   onetimeBlocks: [],
 
+  // Employee Availability Data
+  employeeAvailability: null,
+
   // UI State
   selectedEmployeeId: null,
   activeTab: "overview",
@@ -68,6 +77,7 @@ const initialState: AvailabilityState = {
     schedules: false,
     recurringBreaks: false,
     onetimeBlocks: false,
+    employeeAvailability: false,
   },
 
   // Error states
@@ -75,6 +85,7 @@ const initialState: AvailabilityState = {
     schedules: null,
     recurringBreaks: null,
     onetimeBlocks: null,
+    employeeAvailability: null,
   },
 
   // Modal states
@@ -109,6 +120,7 @@ const availabilitySlice = createSlice({
       state.schedules = [];
       state.recurringBreaks = [];
       state.onetimeBlocks = [];
+      state.employeeAvailability = null;
     },
 
     // Tab navigation
@@ -204,6 +216,29 @@ const availabilitySlice = createSlice({
       );
     },
 
+    // Employee Availability actions
+    setEmployeeAvailabilityLoading: (state, action: PayloadAction<boolean>) => {
+      state.loading.employeeAvailability = action.payload;
+    },
+    setEmployeeAvailabilityError: (
+      state,
+      action: PayloadAction<string | null>
+    ) => {
+      state.error.employeeAvailability = action.payload;
+    },
+    setEmployeeAvailability: (
+      state,
+      action: PayloadAction<EmployeeAvailabilityResponse>
+    ) => {
+      // Store data as-is, time conversion will be handled in component
+      state.employeeAvailability = action.payload;
+      state.loading.employeeAvailability = false;
+      state.error.employeeAvailability = null;
+    },
+    clearEmployeeAvailability: (state) => {
+      state.employeeAvailability = null;
+    },
+
     // Modal actions
     openScheduleModal: (
       state,
@@ -249,6 +284,7 @@ const availabilitySlice = createSlice({
       state.error.schedules = null;
       state.error.recurringBreaks = null;
       state.error.onetimeBlocks = null;
+      state.error.employeeAvailability = null;
     },
   },
 });
@@ -275,6 +311,10 @@ export const {
   addOnetimeBlock,
   updateOnetimeBlock,
   removeOnetimeBlock,
+  setEmployeeAvailabilityLoading,
+  setEmployeeAvailabilityError,
+  setEmployeeAvailability,
+  clearEmployeeAvailability,
   openScheduleModal,
   closeScheduleModal,
   openRecurringBreakModal,
@@ -370,4 +410,9 @@ export const selectErrorStates = createSelector(
 export const selectModalStates = createSelector(
   (state: RootState) => state.availability.modals,
   (modals) => modals
+);
+
+export const selectEmployeeAvailability = createSelector(
+  (state: RootState) => state.availability.employeeAvailability,
+  (employeeAvailability) => employeeAvailability
 );

--- a/apps/business-app/src/store/thunks/availabilityThunk.ts
+++ b/apps/business-app/src/store/thunks/availabilityThunk.ts
@@ -8,6 +8,8 @@ import {
   CreateOnetimeBlockRequest,
   AvailabilityRequest,
   AvailabilityResponse,
+  EmployeeAvailabilityRequest,
+  EmployeeAvailabilityResponse,
 } from "../../types/availability";
 import { availabilityAPI } from "../../utils/availabilityApi";
 import {
@@ -24,6 +26,9 @@ import {
   setOnetimeBlocks,
   addOnetimeBlock,
   updateOnetimeBlock,
+  setEmployeeAvailabilityLoading,
+  setEmployeeAvailabilityError,
+  setEmployeeAvailability,
   closeScheduleModal,
   closeRecurringBreakModal,
   closeOnetimeBlockModal,
@@ -237,6 +242,27 @@ export const checkAvailability = createAsyncThunk<
     return rejectWithValue(message);
   }
 });
+
+// Employee Availability Data Thunk
+export const fetchEmployeeAvailabilityByDate = createAsyncThunk<
+  void,
+  EmployeeAvailabilityRequest,
+  { rejectValue: string }
+>(
+  "availability/fetchEmployeeAvailabilityByDate",
+  async (request, { dispatch, rejectWithValue }) => {
+    try {
+      dispatch(setEmployeeAvailabilityLoading(true));
+      const response =
+        await availabilityAPI.availability.getEmployeeAvailability(request);
+      dispatch(setEmployeeAvailability(response));
+    } catch (error: any) {
+      const message = error.message || "Failed to fetch employee availability";
+      dispatch(setEmployeeAvailabilityError(message));
+      return rejectWithValue(message);
+    }
+  }
+);
 
 // Fetch all data for an employee
 export const fetchEmployeeAvailabilityData = createAsyncThunk<

--- a/apps/business-app/src/types/availability.ts
+++ b/apps/business-app/src/types/availability.ts
@@ -82,7 +82,7 @@ export const DAYS_OF_WEEK: DayOfWeekInfo[] = [
   { value: 6, label: "Saturday", short: "Sat" },
 ];
 
-// Availability checking types
+// Availability checking types (legacy - for service booking)
 export interface AvailabilityRequest {
   service: string[];
   starttime: string; // RFC3339 format
@@ -93,4 +93,35 @@ export interface AvailabilityResponse {
   employeeid: string;
   service: string[];
   EWT: string[]; // Effective Working Time slots
+}
+
+// Employee Availability Data types (new - for staff management)
+export interface EmployeeAvailabilityRequest {
+  date: string; // YYYY-MM-DD format
+  employee_id: string; // UUID string
+}
+
+export interface EmployeeAvailabilitySchedule {
+  start_time: string; // ISO datetime
+  end_time: string; // ISO datetime
+}
+
+export interface EmployeeAvailabilityBlock {
+  start_time: string; // ISO datetime
+  end_time: string; // ISO datetime
+  reason: string;
+}
+
+export interface EmployeeAvailabilityBreak {
+  start_time: string; // ISO datetime
+  end_time: string; // ISO datetime
+  reason: string;
+}
+
+export interface EmployeeAvailabilityResponse {
+  date: string; // ISO date
+  employee_id: string; // UUID string
+  schedule: EmployeeAvailabilitySchedule | null;
+  onetimeblocks: EmployeeAvailabilityBlock[];
+  breaks: EmployeeAvailabilityBreak[];
 }

--- a/apps/business-app/src/utils/availabilityApi.ts
+++ b/apps/business-app/src/utils/availabilityApi.ts
@@ -7,6 +7,8 @@ import {
   CreateOnetimeBlockRequest,
   AvailabilityRequest,
   AvailabilityResponse,
+  EmployeeAvailabilityRequest,
+  EmployeeAvailabilityResponse,
 } from "../types/availability";
 import axiosInstance from "../api/axios";
 
@@ -144,12 +146,23 @@ export const availabilityAPI = {
 
   // Availability Checking
   availability: {
-    // Check employee availability for services and time range
+    // Check employee availability for services and time range (legacy)
     check: async (
       request: AvailabilityRequest
     ): Promise<AvailabilityResponse[]> => {
       const { data } = await axiosInstance.post<AvailabilityResponse[]>(
         "/api/employees/availability",
+        request
+      );
+      return data;
+    },
+
+    // Get employee availability data for a specific date (new)
+    getEmployeeAvailability: async (
+      request: EmployeeAvailabilityRequest
+    ): Promise<EmployeeAvailabilityResponse> => {
+      const { data } = await axiosInstance.post<EmployeeAvailabilityResponse>(
+        "/api/availability",
         request
       );
       return data;

--- a/services/api-gateway/internal/handler/routes.go
+++ b/services/api-gateway/internal/handler/routes.go
@@ -63,5 +63,9 @@ func SetupRoutes(app *fiber.App) {
 	recurringBreaks.Put("/:id", proxy.ForwardToEmployeeService)     // PUT /api/recurring-breaks/:id -> /recurring-breaks/:id
 	recurringBreaks.Delete("/:id", proxy.ForwardToEmployeeService)  // DELETE /api/recurring-breaks/:id -> /recurring-breaks/:id
 
+	// Availability Checking Routes - forwarded to employee service
+	availability := protected.Group("/availability")
+	availability.Post("/", proxy.ForwardToEmployeeService)          // POST /api/availability/ -> /availability
+
 	// Future routes for additional services can be added here
 }


### PR DESCRIPTION
This pull request introduces a new feature to display daily staff availability timelines in the business app, along with supporting changes to the Redux store for managing employee availability data. The most important changes include the creation of the `DailyAvailabilityTimeline` component, updates to the `StaffOverviewTab` component to integrate the timeline, and enhancements to the `availabilitySlice` to handle employee availability data.

### Component Enhancements

* **`DailyAvailabilityTimeline` Component**: Added a new React component to visually represent staff availability, breaks, and time-off for a specific day. It includes helper functions for time calculations, timeline segment generation, and dynamic rendering based on availability data.
* **`StaffOverviewTab` Integration**: Updated the `StaffOverviewTab` component to include the `DailyAvailabilityTimeline`. Added a date picker for selecting the timeline date and logic to fetch availability data dynamically when the staff or date changes. [[1]](diffhunk://#diff-175ec9b1e5a15f52b48c93896924e500c80956c5defb2cb9b980199563126e6cL1-R3) [[2]](diffhunk://#diff-175ec9b1e5a15f52b48c93896924e500c80956c5defb2cb9b980199563126e6cR12-R19) [[3]](diffhunk://#diff-175ec9b1e5a15f52b48c93896924e500c80956c5defb2cb9b980199563126e6cR28-R39) [[4]](diffhunk://#diff-175ec9b1e5a15f52b48c93896924e500c80956c5defb2cb9b980199563126e6cR49-R61) [[5]](diffhunk://#diff-175ec9b1e5a15f52b48c93896924e500c80956c5defb2cb9b980199563126e6cR276-R332)

### Redux Store Updates

* **`availabilitySlice` Enhancements**: Extended the Redux slice to manage employee availability data, including new state properties (`employeeAvailability`, loading, and error states) and actions (`setEmployeeAvailability`, `setEmployeeAvailabilityLoading`, etc.). These changes support fetching and storing availability information for specific dates. [[1]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR8) [[2]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR18-R20) [[3]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR30-R38) [[4]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR68-R70) [[5]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR80-R88) [[6]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR123) [[7]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR219-R241) [[8]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR287) [[9]](diffhunk://#diff-c98aa3824945179b008d380baa61fd811c6d92a4157b699ba7433a22b5ee4f8fR314-R317)