### PR TITLE
Update API URL to DigitalOcean endpoint

### DIFF
--- a/apps/business-app/src/api/axios.ts
+++ b/apps/business-app/src/api/axios.ts
@@ -2,7 +2,8 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
 
 // dynamic env value; fallback to gateway at 8081
 const BASE_URL =
-  import.meta.env.VITE_API_URL || "https://staff-api-gateway.onrender.com";
+  import.meta.env.VITE_API_URL ||
+  "https://staff-scheduler-q2w5f.ondigitalocean.app";
 
 // We'll get the store reference dynamically to avoid circular dependency
 let store: any = null;


### PR DESCRIPTION
- Migrate from Render to DigitalOcean App Platform
- Replace https://staff-api-gateway.onrender.com with https://staff-scheduler-q2w5f.ondigitalocean.app
- Resolve cold start and suspension issues with always-on services